### PR TITLE
Updating browserify and watchify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('copy-component-assets', function() {
 gulp.task('scripts-app', function() {
 
   // app.js
-  var sources = glob.sync('./app/**/*.js')
+  var sources = glob.sync(__dirname + '/app/**/*.js')
 
   var bundler = browserify({
     bundleExternal: false,
@@ -108,18 +108,8 @@ gulp.task('scripts-app', function() {
 
   var bundle = function() {
 
-    // Alias map app controllers
-    var controllersPath = path.join(__dirname, '/app/controllers')
-    var controllers = glob.sync('**/*.js', {cwd: controllersPath})
-
-    controllers.forEach(function(controller) {
-
-      var controllerPath = controllersPath + '/' + controller
-      var controllerName = 'controllers/' + controller.replace('.js', '')
-
-      bundler.require(controllerPath, {expose: controllerName})
-
-    })
+    // Alias expose index controller
+    bundler.require('./app/controllers/index.js', {expose: 'controllers/index'})
 
     // Map to files in vendor.js
     bundler.external('jquery')

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "underscore": "^1.6.0"
   },
   "devDependencies": {
-    "6to5": "^1.9.10",
-    "6to5-browserify": "0.0.11",
-    "browserify": "^4.2.3",
+    "6to5": "^1.10.12",
+    "6to5-browserify": "1.0.0",
+    "browserify": "^6.2.0",
     "chai": "^1.9.2",
     "execSync": "^1.0.2",
     "glob": "^4.0.6",
@@ -67,6 +67,6 @@
     "sinon-chai": "^2.6.0",
     "stylus": "^0.49.2",
     "vinyl-source-stream": "^1.0.0",
-    "watchify": "^0.10.2"
+    "watchify": "^2.1.1"
   }
 }


### PR DESCRIPTION
- Had to use the full filepath when getting sources to bundle, otherwise files were not being found at runtime.
- Had to remap only the index controller

I'm not entirely sure what changed in browserify that made these changes necessary. Something is odd between `browserify.bundle` and the `browser-pack/prelude.js` that mixes full paths with relative paths.
